### PR TITLE
Adding getLength() method in TemplateRecord,java

### DIFF
--- a/src/net/decix/jipfix/header/TemplateRecord.java
+++ b/src/net/decix/jipfix/header/TemplateRecord.java
@@ -17,6 +17,7 @@ import net.decix.util.Utility;
  * @author tking
  */
 public class TemplateRecord extends Record {
+	private final static int HEADERLENGTH = 4;
 	private int templateID;
 	private int fieldCount;
 	private List<InformationElement> informationElements = new ArrayList<InformationElement>();
@@ -90,7 +91,11 @@ public class TemplateRecord extends Record {
 			throw new HeaderBytesException("Error while generating the bytes: " + e.getMessage());
 		}
 	}
-	
+	@Override
+        public int getLength() {
+        return HEADERLENGTH + (informationElements.size() * InformationElement.LENGTH);
+        }
+
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();

--- a/src/net/decix/jipfix/header/TemplateRecord.java
+++ b/src/net/decix/jipfix/header/TemplateRecord.java
@@ -91,6 +91,7 @@ public class TemplateRecord extends Record {
 			throw new HeaderBytesException("Error while generating the bytes: " + e.getMessage());
 		}
 	}
+
 	@Override
         public int getLength() {
         return HEADERLENGTH + (informationElements.size() * InformationElement.LENGTH);


### PR DESCRIPTION
Update TemplateRecord.java
Can you please insert the getLength() method in TemplateRecord,java, as it is required and used by the SetHeader.java. Currently the code in SetHeader will not work correctly as it will not be able to correctly calculate length.
